### PR TITLE
Make it easy to create Issues using the template in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Whether or not strict guidelines have been provided for the project type, our re
 * [ ] Has the Private badge
 
 ### Experimental Tier Minimum Requirements
-* [ ] The Experimental badge
+
+The following list of requirements can be used to create progress tracking issues on new projects as they are transitioned into the desired state.
+
+```
+* [ ] The Experimental badge ![](https://img.shields.io/badge/stability-experimental%20%F0%9F%A7%AA-orange.svg)
 * [ ] The Experimental Statement in the README.md
 * [ ] LICENSE
 * [ ] README.md
@@ -30,9 +34,14 @@ Whether or not strict guidelines have been provided for the project type, our re
 * [ ] Developer Certificate of Origin https://github.com/apps/dco
 * [ ] At least one maintainer
 * [ ] CI/CD
+```
 
 ### Maintained Tier Minimum Requirements
-* [ ] The Maintained badge
+
+The following list of requirements can be used to create progress tracking issues on new projects as they are transitioned into the desired state.
+
+```
+* [ ] The Maintained badge ![](https://img.shields.io/badge/stability-maintained-green.svg)
 * [ ] The Maintained Statement in the README.md
 * [ ] LICENSE
 * [ ] README.md
@@ -45,3 +54,4 @@ Whether or not strict guidelines have been provided for the project type, our re
 * [ ] How to Contribute
 * [ ] SUPPORT.md
 * [ ] RELEASE.md
+```


### PR DESCRIPTION
Makes the Markdown checklist a markdown code block so that it can be easily copy/pasted into issues on projects seeking Packet standardization.

Included are badges:
* ![](https://img.shields.io/badge/stability-experimental%20%F0%9F%A7%AA-orange.svg) (lab coat? explosion? what emoji should we use? what color?)
* ![](https://img.shields.io/badge/stability-maintained-green.svg)

Should the stability statement be included in each projects README? I think it would be sufficient to link out to it. This allows for us to update the statement in one place rather than each repository.

```markdown
### Support

This is an experiment Packet community project, please see
 the [experimental Packet project standards guide for details](...#experimental).
```

Badges should also link to the stability level statement - this should not be the only link.  
